### PR TITLE
fix: fully escape string for usage in require call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@calvin-l/webpack-loader-util": "^1.0.2",
+        "js-string-escape": "^1.0.1",
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0",
         "sharp": "^0.28.1"
@@ -18,6 +19,7 @@
         "@commitlint/cli": "^12.0.1",
         "@commitlint/config-conventional": "^12.0.1",
         "@types/jest": "^26.0.22",
+        "@types/js-string-escape": "^1.0.0",
         "@types/node": "^15.0.2",
         "@types/sharp": "^0.28.0",
         "@types/webpack": "^4.41.25",
@@ -1561,6 +1563,12 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
+    },
+    "node_modules/@types/js-string-escape": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/js-string-escape/-/js-string-escape-1.0.0.tgz",
+      "integrity": "sha512-UANTN9S09hivqbeR4unjVS7DrtgjYUFNK4UCmHGPuwMrHyMFeU3z9KMg0wja/fTflXo7fVl0BsAohlgRO4QowQ==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
@@ -10643,6 +10651,14 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -19550,6 +19566,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/js-string-escape": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/js-string-escape/-/js-string-escape-1.0.0.tgz",
+      "integrity": "sha512-UANTN9S09hivqbeR4unjVS7DrtgjYUFNK4UCmHGPuwMrHyMFeU3z9KMg0wja/fTflXo7fVl0BsAohlgRO4QowQ==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -26691,6 +26713,11 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@calvin-l/webpack-loader-util": "^1.0.2",
+    "js-string-escape": "^1.0.1",
     "loader-utils": "^2.0.0",
     "schema-utils": "^3.0.0",
     "sharp": "^0.28.1"
@@ -47,6 +48,7 @@
     "@commitlint/cli": "^12.0.1",
     "@commitlint/config-conventional": "^12.0.1",
     "@types/jest": "^26.0.22",
+    "@types/js-string-escape": "^1.0.0",
     "@types/node": "^15.0.2",
     "@types/sharp": "^0.28.0",
     "@types/webpack": "^4.41.25",

--- a/src/helpers/getRequireStringWithModifiedResizeLoaderOptions.ts
+++ b/src/helpers/getRequireStringWithModifiedResizeLoaderOptions.ts
@@ -1,3 +1,4 @@
+import escapeString from "js-string-escape";
 import { parseQuery } from "loader-utils";
 import { loader } from "webpack";
 
@@ -54,11 +55,12 @@ export default async function getRequireStringWithModifiedResizeLoaderOptions(
         )
       )
     );
-  const newRequestString = remainingRequest
-    .replace(resizeLoaderRequest, newResizeLoaderQuery)
-    .replace(/\\/g, "\\\\");
+  const newRequestString = remainingRequest.replace(
+    resizeLoaderRequest,
+    newResizeLoaderQuery
+  );
 
-  return newRequestString;
+  return escapeString(newRequestString);
 }
 
 // needed so webpack doesn't mistake "!" for query operator "!"

--- a/test/unit/getRequireStringWithModifiedResizeLoaderOptions.test.ts
+++ b/test/unit/getRequireStringWithModifiedResizeLoaderOptions.test.ts
@@ -54,7 +54,7 @@ it("should handle resizeLoaderPath options being string", async () => {
   );
 
   expect(result).toMatchInlineSnapshot(
-    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{"test":3,"scaleUp":true}!/home/username/project-name/src/assets/Macaca_nigra_self-portrait_large.jpg"`
+    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{\\"test\\":3,\\"scaleUp\\":true}!/home/username/project-name/src/assets/Macaca_nigra_self-portrait_large.jpg"`
   );
 });
 
@@ -106,7 +106,7 @@ it("should handle resizeLoaderPath options being object", async () => {
   );
 
   expect(result).toMatchInlineSnapshot(
-    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{"test":3,"scaleUp":true}!/home/username/project-name/src/assets/Macaca_nigra_self-portrait_large.jpg"`
+    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{\\"test\\":3,\\"scaleUp\\":true}!/home/username/project-name/src/assets/Macaca_nigra_self-portrait_large.jpg"`
   );
 });
 
@@ -158,7 +158,7 @@ it("should handle resizeLoaderPath options being undefined", async () => {
   );
 
   expect(result).toMatchInlineSnapshot(
-    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{"scaleUp":true}!/home/username/project-name/src/assets/Macaca_nigra_self-portrait_large.jpg"`
+    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{\\"scaleUp\\":true}!/home/username/project-name/src/assets/Macaca_nigra_self-portrait_large.jpg"`
   );
 });
 
@@ -264,6 +264,58 @@ it("should handle resizeLoaderOptionsGenerator", async () => {
   );
 
   expect(result).toMatchInlineSnapshot(
-    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{"test":"true"}!/home/username/project-name/src/assets/Macaca_nigra_self-portrait_large.jpg"`
+    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{\\"test\\":\\"true\\"}!/home/username/project-name/src/assets/Macaca_nigra_self-portrait_large.jpg"`
+  );
+});
+
+it("should fully escape JS string for use in require", async () => {
+  const fileLoaderPath = require.resolve("file-loader");
+  const resizeLoaderName = "webpack-image-resize-loader";
+  const resizeLoaderPath = require.resolve(resizeLoaderName);
+  const remainingRequest = `${fileLoaderPath}??ruleSet[1].rules[1].use[0]!${resizeLoaderPath}??ruleSet[1].rules[1].use[1]!/home/username/project-name/src/assets/Macaca_nigra_'self-portrait'_large.jpg`;
+  const loaders: {
+    path: string;
+    request: string;
+    options?: Record<string, any> | string;
+  }[] = [
+    {
+      path: "webpack-image-srcset-loader",
+      request: 'webpack-image-srcset-loader?{"test":5}',
+      options: undefined,
+    },
+    {
+      path: fileLoaderPath,
+      request: `${fileLoaderPath}??ruleSet[1].rules[1].use[0]`,
+      options: { test: 5 },
+    },
+    {
+      path: resizeLoaderPath,
+      request: `${resizeLoaderPath}??ruleSet[1].rules[1].use[1]`,
+      options: '{"test":3}',
+    },
+  ];
+  const loaderIndex = 0;
+  const options = {};
+  const resizeLoaderOptionsGenerator = defaultResizeLoaderOptionsGenerator;
+  const context = { loaders, loaderIndex } as loader.LoaderContext;
+
+  jest.doMock("../../src/helpers/resolveLoader", () => ({
+    __esModule: true,
+    default: async () => resizeLoaderPath,
+  }));
+
+  const getRequireString = require("../../src/helpers/getRequireStringWithModifiedResizeLoaderOptions")
+    .default;
+
+  const result = await getRequireString(
+    context,
+    remainingRequest,
+    options,
+    resizeLoaderName,
+    resizeLoaderOptionsGenerator
+  );
+
+  expect(result).toMatchInlineSnapshot(
+    `"<rootDir>/node_modules/file-loader/dist/cjs.js??ruleSet[1].rules[1].use[0]!<rootDir>/node_modules/webpack-image-resize-loader/dist/cjs.js?{\\"test\\":3,\\"scaleUp\\":true}!/home/username/project-name/src/assets/Macaca_nigra_\\'self-portrait\\'_large.jpg"`
   );
 });


### PR DESCRIPTION
I was trying to use this loader in a project of mine and ran into some issues with certain file names I'm trying to load. Specifically, I have images whose file names contain single quotes `'`. This package would insert them into the generated `require` call as-is, leading to a parse error later on.

As the package cannot control the file names it receives, it has to take care of fully escaping the string spliced into the generated module code. I have used the [js-string-escape](https://www.npmjs.com/package/js-string-escape) package for this, but the escape function is simple enough that it could also just be included in this package.